### PR TITLE
[gitter-api-ruby.gemspec] Update rake dep

### DIFF
--- a/gitter-api.gemspec
+++ b/gitter-api.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*"] + %w[README.md LICENSE.txt]
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake",     "~> 10.0"
+  spec.add_development_dependency "rake",     ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
For CVE-2020-8130:

> There is an OS command injection vulnerability in Ruby Rake before
> 12.3.3 in `Rake::FileList` when supplying a filename that begins with
> the pipe character `|`.

I assume it is pretty minor and hard to exploit, but doesn't hurt to make the change.